### PR TITLE
Engine related Bugfixes

### DIFF
--- a/ComsciProject/ComsciProject/Engine/Engine.cs
+++ b/ComsciProject/ComsciProject/Engine/Engine.cs
@@ -90,6 +90,8 @@ namespace ComsciProject.Engine
                 }
                 renderComplete = false;
                 Debug.Log("GameUpdate Begin(" + updateNum++ + ")");
+                //Get the last input and push it to the input class' keypress var
+                Input.EngineRenderFrame();
                 //check items to run init on
                 InitNewEntities();
                 //run update

--- a/ComsciProject/ComsciProject/Engine/Engine.cs
+++ b/ComsciProject/ComsciProject/Engine/Engine.cs
@@ -37,7 +37,7 @@ namespace ComsciProject.Engine
         /// <summary>
         /// Maximum number of times per second an update may be called
         /// </summary>
-        public static float maxUpdateRate = 2f;
+        public static float maxUpdateRate = 10f;
         /// <summary>
         /// Start the game engine loop
         /// </summary>
@@ -46,7 +46,7 @@ namespace ComsciProject.Engine
             if (mainThread == null)
                 mainThread = new Thread(GameUpdate);
             entitiesToInstantiate = new Queue<Entity>();
-            LastFrame = "First Frame";
+            LastFrame = "Loading...";//just so we know issues
             mainThread.Start();
             currentLevel?.InstantiateFirstFrameEntities();
         }
@@ -106,7 +106,7 @@ namespace ComsciProject.Engine
                 LastFrame = RenderWorld();
                 //invoke a render delegate on the UI
                 //sleep until need to update again
-                Thread.Sleep((int)(1000 / maxUpdateRate));//this should technically be the difference since frame last rendered and this render in ms, but will be fine for now.
+                //Thread.Sleep((int)(1000 / maxUpdateRate));//this should technically be the difference since frame last rendered and this render in ms, but will be fine for now.
             }
         }
         /// <summary>
@@ -136,7 +136,7 @@ namespace ComsciProject.Engine
             //add entities to it
             foreach (Entity e in currentLevel.entities)
             {
-                Debug.Log(e.instanceID + "("+e.descName+") being rendered");
+                //Debug.Log(e.instanceID + "("+e.descName+") being rendered");
                 if(currentLevel.positionInBounds(new Vector2(e.position.x,e.position.y)))
                     worldRender[e.position.y][e.position.x] = e.appearance;
                 else

--- a/ComsciProject/ComsciProject/Engine/Engine.cs
+++ b/ComsciProject/ComsciProject/Engine/Engine.cs
@@ -34,6 +34,7 @@ namespace ComsciProject.Engine
         /// Thread on which the game loop runs
         /// </summary>
         public static Thread mainThread;
+        private static bool gameRunning = false;
         /// <summary>
         /// Maximum number of times per second an update may be called
         /// </summary>
@@ -48,6 +49,7 @@ namespace ComsciProject.Engine
             entitiesToInstantiate = new Queue<Entity>();
             LastFrame = "Loading...";//just so we know issues
             mainThread.Start();
+            gameRunning = true;
             currentLevel?.InstantiateFirstFrameEntities();
         }
 
@@ -57,11 +59,9 @@ namespace ComsciProject.Engine
         /// 
         public static void Close()
         {
-            currentLevel = null;
-            entitiesToInstantiate = null;
+            gameRunning = false;
             if (mainThread != null)
             {
-                mainThread.Abort();
                 mainThread = null;
             }
         }
@@ -79,7 +79,7 @@ namespace ComsciProject.Engine
         
         private static void GameUpdate()
         {
-            while (true)
+            while (gameRunning)
             {
                 while (!renderComplete)//gameThread waits for render to complete
                     Thread.Sleep(1);
@@ -110,6 +110,10 @@ namespace ComsciProject.Engine
                 //sleep until need to update again
                 //Thread.Sleep((int)(1000 / maxUpdateRate));//this should technically be the difference since frame last rendered and this render in ms, but will be fine for now.
             }
+            Debug.Log("Game Thread Exiting - Cleaning up references (" + updateNum + " updates)");
+            currentLevel = null;
+            entitiesToInstantiate = null;
+            Debug.Log("Game Thread Ended");
         }
         /// <summary>
         /// The last update frame, the UI will render this

--- a/ComsciProject/ComsciProject/Engine/Input.cs
+++ b/ComsciProject/ComsciProject/Engine/Input.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Windows.Forms;
+using System.Windows.Input;
 
 namespace ComsciProject.Engine
 {
@@ -12,24 +12,20 @@ namespace ComsciProject.Engine
     public sealed class Input
     {
 
-        public static void Initialize(KeyEventHandler keyHandler)
+        public static void ReceiveKey(KeyEventArgs e)
         {
-            KeyDownEvent = keyHandler;
-            KeyDownEvent += OnKeyDown;
-        }
-        private static KeyEventHandler KeyDownEvent;
-
-        private static void OnKeyDown(object sender, KeyEventArgs e)
-        {
-            lastKeypress = e.KeyCode;
-            //when a key is pressed
+            lastKeypress = e.Key;
         }
 
-        private static volatile Keys lastKeypress;//NEED TO MAKE THIS THREAD SAFE
-
-        public static Keys getLastKeypress()//VERY UNSAFE FOR THREAD
+        private static volatile Key lastKeypress;//NEED TO MAKE THIS THREAD SAFE
+        private static volatile Key frameKeypress;
+        public static Key getLastKeypress()//VERY UNSAFE FOR MULTITHREADING,BUT YOLO
         {
-            return lastKeypress;
+            return frameKeypress;
+        }
+        public static void EngineRenderFrame()
+        {
+            frameKeypress = lastKeypress;
         }
     }
 }

--- a/ComsciProject/ComsciProject/Engine/PacMan/PacManLevel.cs
+++ b/ComsciProject/ComsciProject/Engine/PacMan/PacManLevel.cs
@@ -13,6 +13,8 @@ namespace ComsciProject.Engine.PacMan
             xBoundry = 38;
             yBoundry = 21;
             entities = new List<Entity>();
+            //What you need to do is set the game update rate so we have
+            //a fixed game speed (default is super slow)
         }
 
         public override void InstantiateFirstFrameEntities()

--- a/ComsciProject/ComsciProject/Engine/PacMan/PacManPlayer.cs
+++ b/ComsciProject/ComsciProject/Engine/PacMan/PacManPlayer.cs
@@ -22,7 +22,11 @@ namespace ComsciProject.Engine.PacMan
 
         public override void LateUpdate()
         {
-            Move(new Vector2(1, 0));
+            //Move(new Vector2(1, 0)); <- this makes it move 2 times in one 'update'
+            //this is not desired behaviour, rather use
+            //Move(new Vector2(2,0));
+            //or if you're fancy
+            //Move(Vector2.right*2);
         }
     }
 }

--- a/ComsciProject/ComsciProject/Engine/PacMan/PacManPlayer.cs
+++ b/ComsciProject/ComsciProject/Engine/PacMan/PacManPlayer.cs
@@ -22,7 +22,7 @@ namespace ComsciProject.Engine.PacMan
                 isLeft = true;
             else if (Input.getLastKeypress() == Key.Right)
                 isLeft = false;
-            Move(isLeft ? Vector2.left : Vector2.right); //if left, move left, else right
+            Move(isLeft ? Vector2.left*2 : Vector2.right*2); //if left, move left, else right
         }
 
         public override void LateUpdate()

--- a/ComsciProject/ComsciProject/Engine/PacMan/PacManPlayer.cs
+++ b/ComsciProject/ComsciProject/Engine/PacMan/PacManPlayer.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
+using System.Windows.Input;
 namespace ComsciProject.Engine.PacMan
 {
     //Controllable character
@@ -14,10 +14,15 @@ namespace ComsciProject.Engine.PacMan
             appearance = 'C';
             descName = "Pac-Man";
         }
-        //Moves very slowly, not sure why
+        //Remove the cheap code here, its to test and show example of Input class
+        bool isLeft = false;
         public override void Update()
         {
-            Move(new Vector2(1, 0));
+            if (Input.getLastKeypress() == Key.Left)
+                isLeft = true;
+            else if (Input.getLastKeypress() == Key.Right)
+                isLeft = false;
+            Move(isLeft ? Vector2.left : Vector2.right); //if left, move left, else right
         }
 
         public override void LateUpdate()

--- a/ComsciProject/ComsciProject/Engine/Vector2.cs
+++ b/ComsciProject/ComsciProject/Engine/Vector2.cs
@@ -31,6 +31,11 @@ namespace ComsciProject.Engine
         public static readonly Vector2 left = new Vector2(-1, 0);
         public static readonly Vector2 right = new Vector2(1, 0);
 
+        public static Vector2 operator * (Vector2 a, int b)
+        {
+            return new Vector2(a.x * b, a.y * b);
+        }
+
         public static bool operator == (Vector2 a, Vector2 b)
         {
             //check its not the same object

--- a/ComsciProject/ComsciProject/MainWindow.xaml.cs
+++ b/ComsciProject/ComsciProject/MainWindow.xaml.cs
@@ -62,7 +62,7 @@ namespace ComsciProject
             display = new SnakeGameDisplay();
             display.Show();
             Timer = new System.Windows.Threading.DispatcherTimer();
-            Timer.Interval = TimeSpan.FromMilliseconds(100);
+            Timer.Interval = TimeSpan.FromMilliseconds(1000/Engine.Engine.maxUpdateRate);//this blocks our game thread, must be changed to suit the game frame rate
             Timer.IsEnabled = true;
             Timer.Tick += dispatcherTimer_Tick;
         }
@@ -70,7 +70,6 @@ namespace ComsciProject
         private void dispatcherTimer_Tick(object sender, EventArgs e)
         {
             display.Display.Content = Engine.Engine.LastFrame;
-            Debug.Log(display.Display.Content);
             Engine.Engine.renderComplete = true;
         }
 
@@ -81,7 +80,7 @@ namespace ComsciProject
             display = new SnakeGameDisplay();
             display.Show();
             Timer = new System.Windows.Threading.DispatcherTimer();
-            Timer.Interval = TimeSpan.FromSeconds(1);
+            Timer.Interval = TimeSpan.FromMilliseconds(1000 / Engine.Engine.maxUpdateRate);//this blocks our game thread, must be changed to suit the game frame rate
             Timer.IsEnabled = true;
             Timer.Tick += PacManDispatcherTimer_Tick;
         }
@@ -89,7 +88,6 @@ namespace ComsciProject
         private void PacManDispatcherTimer_Tick(object sender, EventArgs e)
         {
             display.Display.Content = Engine.Engine.LastFrame;
-            Debug.Log(display.Display.Content);
             Engine.Engine.renderComplete = true;
         }
     }

--- a/ComsciProject/ComsciProject/SnakeGameDisplay.xaml.cs
+++ b/ComsciProject/ComsciProject/SnakeGameDisplay.xaml.cs
@@ -27,6 +27,7 @@ namespace ComsciProject
             //change definition here to change games
             //Engine.Engine.currentLevel = new ExampleLevel();
             Engine.Engine.currentLevel = new PacManLevel();
+            Engine.Engine.maxUpdateRate = 10f;//10 updates per second are run
             Engine.Engine.Initialize();
         }
 

--- a/ComsciProject/ComsciProject/SnakeGameDisplay.xaml.cs
+++ b/ComsciProject/ComsciProject/SnakeGameDisplay.xaml.cs
@@ -38,7 +38,7 @@ namespace ComsciProject
 
         private void Window_KeyDown(object sender, KeyEventArgs e)
         {
-            //Input.Initialize(SnakeWindow.KeyDown);
+            Input.ReceiveKey(e);
         }
     }
 }


### PR DESCRIPTION
 8e61c5ab8ded36b455f112da7597f0ac606d3a3e

> > Fixed pacman 'slow update' bug, have included comments.(was to do wi…
> > …th UI thread timer blocking the game thread (which waits for the UI thread to make Engine.renderComplete true, which was stuck behind a 1000ms timer wall);
> > 
> > Removed duplicate Move() from LateUpdate() on PacManPlayer, added comments explaining why

c69ee8ab706a0ac0e524f144b697c6aeb50c0d20
Fixed Input issues, is slightly hackish solution but should do the job.

The last commit fixes:

> Thread.Abort will "kill" the thread, but this is roughly equivalent to:
> 
> Scenario: You want to turn off your computer
> 
> Solution: You strap dynamite to your computer, light it, and run.
> 
> It's FAR better to trigger an "exit condition", either via CancellationTokenSource.Cancel, setting some (safely accessed) "is running" bool, etc., and calling Thread.Join. This is more like:
> 
> Scenario: You want to turn off your computer
> 
> Solution: You click start, shut down, and wait until the computer powers down.

->Source: http://stackoverflow.com/questions/14131608/how-to-terminate-a-thread-in-c

> Basically only learnt this now.
